### PR TITLE
SD Card Command 

### DIFF
--- a/main.js
+++ b/main.js
@@ -218,7 +218,7 @@ class OctoPrint extends utils.Adapter {
                             }
                         );
                     } else {
-                        this.log.error('print job command not allowed: ' + state.val + '. Choose one of: ' + allowedCommands.join(', '));
+                        this.log.error('sd card command not allowed: ' + state.val + '. Choose one of: ' + allowedCommands.join(', '));
                     }
 
                 } else if (id === this.namespace + '.command.custom') {


### PR DESCRIPTION
Hi,

als ich ein paar Custom Kommandos bei mir eingerichtet habe, ist mir aufgefallen, dass der Error Output für das Printjob Kommando und SD Card Kommando gleich ist und etwas verwirrend wirkt.

Ich habe entsprechend einen PR mit der kleinen Ausgabeänderung erstellt ;-) 

Viele Grüße

thost96 